### PR TITLE
Added square brackets to Community validation regex

### DIFF
--- a/netbox_bgp/models.py
+++ b/netbox_bgp/models.py
@@ -113,7 +113,7 @@ class Community(BGPBase):
     """
     value = models.CharField(
         max_length=64,
-        validators=[RegexValidator(r'[\d\.\*]+:[\d\.\*]+')]
+        validators=[RegexValidator(r'[\d\.\[\]\*]+:[\d\.\[\]\*]+')]
     )
 
     class Meta:


### PR DESCRIPTION
Since community objects used by a community list often need to be in regex format, I've added square brackets to the RegexValidator pattern for the community object.