### PR TITLE
Add Journaling to objects

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*    @k01ek @cruse1977 @natm

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ This plugin provide following Models:
 
 ## Compatibility
 
-|               |           |
-|---------------|-----------|
-| NetBox 3.4.x  | >= 0.9.0  |
-| NetBox 3.5.x  | >= 0.10.0 |
-| NetBox 3.6.x  | >= 0.11.0 |
-| NetBox 3.7.x  | >= 0.12.0 |
-| NetBox 4.0.x  | >= 0.13.2 |
+|             |           |
+|-------------|-----------|
+| NetBox 3.4  | >= 0.9.0  |
+| NetBox 3.5  | >= 0.10.0 |
+| NetBox 3.6  | >= 0.11.0 |
+| NetBox 3.7  | >= 0.12.0 |
+| NetBox 4.0  | >= 0.13.2 |
 
 ## Installation
 

--- a/netbox_bgp/templates/netbox_bgp/bgppeergroup.html
+++ b/netbox_bgp/templates/netbox_bgp/bgppeergroup.html
@@ -9,20 +9,6 @@
 <li class="breadcrumb-item"><a href="{% url 'plugins:netbox_bgp:bgppeergroup_list' %}">Peer Groups</a></li>
 {% endblock %}
 
-{% block tabs %}
-<ul class="nav nav-tabs px-3">
-    {% block tab_items %}
-    <li class="nav-item" role="presentation">
-        <a class="nav-link{% if not active_tab %} active{% endif %}" href="{{ object.get_absolute_url }}">{{ object|meta:"verbose_name"|bettertitle }}</a>
-    </li>
-    {% endblock tab_items %}
-    {% if perms.extras.view_objectchange %}
-    <li role="presentation" class="nav-item">
-        <a href="{% url 'plugins:netbox_bgp:bgppeergroup_changelog' pk=object.pk %}" class="nav-link{% if active_tab == 'changelog'%} active{% endif %}">Change Log</a>
-    </li>
-    {% endif %}
-</ul>
-{% endblock tabs %}
 
 {% block content %}
 <div class="row mb-3">

--- a/netbox_bgp/templates/netbox_bgp/bgpsession.html
+++ b/netbox_bgp/templates/netbox_bgp/bgpsession.html
@@ -9,20 +9,6 @@
 <li class="breadcrumb-item"><a href="{% url 'plugins:netbox_bgp:bgpsession_list' %}">BGP Sessions</a></li>
 {% endblock %}
 
-{% block tabs %}
-<ul class="nav nav-tabs px-3">
-    {% block tab_items %}
-    <li class="nav-item" role="presentation">
-        <a class="nav-link{% if not active_tab %} active{% endif %}" href="{{ object.get_absolute_url }}">{{ object|meta:"verbose_name"|bettertitle }}</a>
-    </li>
-    {% endblock tab_items %}
-    {% if perms.extras.view_objectchange %}
-    <li role="presentation" class="nav-item">
-        <a href="{% url 'plugins:netbox_bgp:bgpsession_changelog' pk=object.pk %}" class="nav-link{% if active_tab == 'changelog'%} active{% endif %}">Change Log</a>
-    </li>
-    {% endif %}
-</ul>
-{% endblock tabs %}
 
 {% block content %}
 <div class="row mb-3">

--- a/netbox_bgp/templates/netbox_bgp/community.html
+++ b/netbox_bgp/templates/netbox_bgp/community.html
@@ -8,20 +8,6 @@
 <li class="breadcrumb-item"><a href="{% url 'plugins:netbox_bgp:community_list' %}">Communities</a></li>
 {% endblock %}
 
-{% block tabs %}
-<ul class="nav nav-tabs px-3">
-    {% block tab_items %}
-    <li class="nav-item" role="presentation">
-        <a class="nav-link{% if not active_tab %} active{% endif %}" href="{{ object.get_absolute_url }}">{{ object|meta:"verbose_name"|bettertitle }}</a>
-    </li>
-    {% endblock tab_items %}
-    {% if perms.extras.view_objectchange %}
-    <li role="presentation" class="nav-item">
-        <a href="{% url 'plugins:netbox_bgp:community_changelog' pk=object.pk %}" class="nav-link{% if active_tab == 'changelog'%} active{% endif %}">Change Log</a>
-    </li>
-    {% endif %}
-</ul>
-{% endblock tabs %}
 
 {% block content %}
 <div class="row mb-3">

--- a/netbox_bgp/templates/netbox_bgp/communitylist.html
+++ b/netbox_bgp/templates/netbox_bgp/communitylist.html
@@ -17,20 +17,6 @@
     {% endif %}
 </div>
 {% endblock extra_controls %}
-{% block tabs %}
-<ul class="nav nav-tabs px-3">
-    {% block tab_items %}
-    <li class="nav-item" role="presentation">
-        <a class="nav-link{% if not active_tab %} active{% endif %}" href="{{ object.get_absolute_url }}">{{ object|meta:"verbose_name"|bettertitle }}</a>
-    </li>
-    {% endblock tab_items %}
-    {% if perms.extras.view_objectchange %}
-    <li role="presentation" class="nav-item">
-        <a href="{% url 'plugins:netbox_bgp:communitylist_changelog' pk=object.pk %}" class="nav-link{% if active_tab == 'changelog'%} active{% endif %}">Change Log</a>
-    </li>
-    {% endif %}
-</ul>
-{% endblock tabs %}
 
 {% block content %}
 <div class="row mb-3">

--- a/netbox_bgp/templates/netbox_bgp/prefixlist.html
+++ b/netbox_bgp/templates/netbox_bgp/prefixlist.html
@@ -17,20 +17,6 @@
     {% endif %}
 </div>
 {% endblock extra_controls %}
-{% block tabs %}
-<ul class="nav nav-tabs px-3">
-    {% block tab_items %}
-    <li class="nav-item" role="presentation">
-        <a class="nav-link{% if not active_tab %} active{% endif %}" href="{{ object.get_absolute_url }}">{{ object|meta:"verbose_name"|bettertitle }}</a>
-    </li>
-    {% endblock tab_items %}
-    {% if perms.extras.view_objectchange %}
-    <li role="presentation" class="nav-item">
-        <a href="{% url 'plugins:netbox_bgp:prefixlist_changelog' pk=object.pk %}" class="nav-link{% if active_tab == 'changelog'%} active{% endif %}">Change Log</a>
-    </li>
-    {% endif %}
-</ul>
-{% endblock tabs %}
 
 {% block content %}
 <div class="row mb-3">

--- a/netbox_bgp/templates/netbox_bgp/routingpolicy.html
+++ b/netbox_bgp/templates/netbox_bgp/routingpolicy.html
@@ -17,20 +17,6 @@
     {% endif %}
 </div>
 {% endblock extra_controls %}
-{% block tabs %}
-<ul class="nav nav-tabs px-3">
-    {% block tab_items %}
-    <li class="nav-item" role="presentation">
-        <a class="nav-link{% if not active_tab %} active{% endif %}" href="{{ object.get_absolute_url }}">{{ object|meta:"verbose_name"|bettertitle }}</a>
-    </li>
-    {% endblock tab_items %}
-    {% if perms.extras.view_objectchange %}
-    <li role="presentation" class="nav-item">
-        <a href="{% url 'plugins:netbox_bgp:routingpolicy_changelog' pk=object.pk %}" class="nav-link{% if active_tab == 'changelog'%} active{% endif %}">Change Log</a>
-    </li>
-    {% endif %}
-</ul>
-{% endblock tabs %}
 
 {% block content %}
 <div class="row mb-3">

--- a/netbox_bgp/urls.py
+++ b/netbox_bgp/urls.py
@@ -1,12 +1,14 @@
-from django.urls import path
-from netbox.views.generic import ObjectChangeLogView
+from django.urls import include, path
+from utilities.urls import get_model_urls
+
 from .models import (
     BGPSession, Community, RoutingPolicy,
     BGPPeerGroup, RoutingPolicyRule, PrefixList,
     PrefixListRule, CommunityList, CommunityListRule
 )
-
 from . import views
+
+app_name = 'netbox_bgp'
 
 urlpatterns = [
     # Community
@@ -18,7 +20,7 @@ urlpatterns = [
     path('community/<int:pk>/', views.CommunityView.as_view(), name='community'),
     path('community/<int:pk>/edit/', views.CommunityEditView.as_view(), name='community_edit'),
     path('community/<int:pk>/delete/', views.CommunityDeleteView.as_view(), name='community_delete'),
-    path('community/<int:pk>/changelog/', ObjectChangeLogView.as_view(), name='community_changelog', kwargs={'model': Community}),
+    path('community/<int:pk>/', include(get_model_urls('netbox_bgp', 'community'))),
     # Community Lists
     path('community-list/', views.CommunityListListView.as_view(), name='communitylist_list'),
     path('community-list/add/', views.CommunityListEditView.as_view(), name='communitylist_add'),
@@ -28,7 +30,7 @@ urlpatterns = [
     path('community-list/<int:pk>/', views.CommListView.as_view(), name='communitylist'),
     path('community-list/<int:pk>/edit/', views.CommunityListEditView.as_view(), name='communitylist_edit'),
     path('community-list/<int:pk>/delete/', views.CommunityListDeleteView.as_view(), name='communitylist_delete'),
-    path('community-list/<int:pk>/changelog/', ObjectChangeLogView.as_view(), name='communitylist_changelog', kwargs={'model': CommunityList}),
+    path('community-list/<int:pk>/', include(get_model_urls('netbox_bgp', 'communitylist'))),
     # Community List Rules
     path('community-list-rule/', views.CommunityListRuleListView.as_view(), name='communitylistrule_list'),
     path('community-list-rule/add/', views.CommunityListRuleEditView.as_view(), name='communitylistrule_add'),
@@ -36,7 +38,7 @@ urlpatterns = [
     path('community-list-rule/<int:pk>/', views.CommunityListRuleView.as_view(), name='communitylistrule'),
     path('community-list-rule/<int:pk>/edit/', views.CommunityListRuleEditView.as_view(), name='communitylistrule_edit'),
     path('community-list-rule/<int:pk>/delete/', views.CommunityListRuleDeleteView.as_view(), name='communitylistrule_delete'),
-    path('community-list-rule/<int:pk>/changelog/', ObjectChangeLogView.as_view(), name='communitylistrule_changelog', kwargs={'model': CommunityListRule}),    
+    path('community-list-rule/<int:pk>/', include(get_model_urls('netbox_bgp', 'communitylistrule'))),
     # Sessions
     path('session/', views.BGPSessionListView.as_view(), name='bgpsession_list'),
     path('session/add/', views.BGPSessionAddView.as_view(), name='bgpsession_add'),
@@ -46,7 +48,7 @@ urlpatterns = [
     path('session/<int:pk>/', views.BGPSessionView.as_view(), name='bgpsession'),
     path('session/<int:pk>/edit/', views.BGPSessionEditView.as_view(), name='bgpsession_edit'),
     path('session/<int:pk>/delete/', views.BGPSessionDeleteView.as_view(), name='bgpsession_delete'),
-    path('session/<int:pk>/changelog/', ObjectChangeLogView.as_view(), name='bgpsession_changelog', kwargs={'model': BGPSession}),
+    path('session/<int:pk>/', include(get_model_urls('netbox_bgp', 'bgpsession'))),
     # Routing Policies
     path('routing-policy/', views.RoutingPolicyListView.as_view(), name='routingpolicy_list'),
     path('routing-policy/add/', views.RoutingPolicyEditView.as_view(), name='routingpolicy_add'),
@@ -56,7 +58,7 @@ urlpatterns = [
     path('routing-policy/<int:pk>/', views.RoutingPolicyView.as_view(), name='routingpolicy'),
     path('routing-policy/<int:pk>/edit/', views.RoutingPolicyEditView.as_view(), name='routingpolicy_edit'),
     path('routing-policy/<int:pk>/delete/', views.RoutingPolicyDeleteView.as_view(), name='routingpolicy_delete'),
-    path('routing-policy/<int:pk>/changelog/', ObjectChangeLogView.as_view(), name='routingpolicy_changelog', kwargs={'model': RoutingPolicy}),
+    path('routing-policy<int:pk>/', include(get_model_urls('netbox_bgp', 'routingpolicy'))),
     # Peer Groups
     path('peer-group/', views.BGPPeerGroupListView.as_view(), name='bgppeergroup_list'),
     path('peer-group/add/', views.BGPPeerGroupEditView.as_view(), name='bgppeergroup_add'),
@@ -66,7 +68,7 @@ urlpatterns = [
     path('peer-group/<int:pk>/', views.BGPPeerGroupView.as_view(), name='bgppeergroup'),
     path('peer-group/<int:pk>/edit/', views.BGPPeerGroupEditView.as_view(), name='bgppeergroup_edit'),
     path('peer-group/<int:pk>/delete/', views.BGPPeerGroupDeleteView.as_view(), name='bgppeergroup_delete'),
-    path('peer-group/<int:pk>/changelog/', ObjectChangeLogView.as_view(), name='bgppeergroup_changelog', kwargs={'model': BGPPeerGroup}),
+    path('peer-group/<int:pk>/', include(get_model_urls('netbox_bgp', 'bgppeergroup'))),
     # Routing Policy Rules
     path('routing-policy-rule/', views.RoutingPolicyRuleListView.as_view(), name='routingpolicyrule_list'),
     path('routing-policy-rule/add/', views.RoutingPolicyRuleEditView.as_view(), name='routingpolicyrule_add'),
@@ -74,7 +76,7 @@ urlpatterns = [
     path('routing-policy-rule/<int:pk>/', views.RoutingPolicyRuleView.as_view(), name='routingpolicyrule'),
     path('routing-policy-rule/<int:pk>/edit/', views.RoutingPolicyRuleEditView.as_view(), name='routingpolicyrule_edit'),
     path('routing-policy-rule/<int:pk>/delete/', views.RoutingPolicyRuleDeleteView.as_view(), name='routingpolicyrule_delete'),
-    path('routing-policy-rule/<int:pk>/changelog/', ObjectChangeLogView.as_view(), name='routingpolicyrule_changelog', kwargs={'model': RoutingPolicyRule}),
+    path('routing-policy-rule/<int:pk>/', include(get_model_urls('netbox_bgp', 'routingpolicyrule'))),
     # Prefix Lists
     path('prefix-list/', views.PrefixListListView.as_view(), name='prefixlist_list'),
     path('prefix-list/add/', views.PrefixListEditView.as_view(), name='prefixlist_add'),
@@ -84,7 +86,7 @@ urlpatterns = [
     path('prefix-list/<int:pk>/', views.PrefixListView.as_view(), name='prefixlist'),
     path('prefix-list/<int:pk>/edit/', views.PrefixListEditView.as_view(), name='prefixlist_edit'),
     path('prefix-list/<int:pk>/delete/', views.PrefixListDeleteView.as_view(), name='prefixlist_delete'),
-    path('prefix-list/<int:pk>/changelog/', ObjectChangeLogView.as_view(), name='prefixlist_changelog', kwargs={'model': PrefixList}),
+    path('prefix-list/<int:pk>/', include(get_model_urls('netbox_bgp', 'prefixlist'))),
     # Prefix List Rules
     path('prefix-list-rule/', views.PrefixListRuleListView.as_view(), name='prefixlistrule_list'),
     path('prefix-list-rule/add/', views.PrefixListRuleEditView.as_view(), name='prefixlistrule_add'),
@@ -92,5 +94,5 @@ urlpatterns = [
     path('prefix-list-rule/<int:pk>/', views.PrefixListRuleView.as_view(), name='prefixlistrule'),
     path('prefix-list-rule/<int:pk>/edit/', views.PrefixListRuleEditView.as_view(), name='prefixlistrule_edit'),
     path('prefix-list-rule/<int:pk>/delete/', views.PrefixListRuleDeleteView.as_view(), name='prefixlistrule_delete'),
-    path('prefix-list-rule/<int:pk>/changelog/', ObjectChangeLogView.as_view(), name='prefixlistrule_changelog', kwargs={'model': PrefixListRule}),
+    path('prefix-list-rule/<int:pk>/', include(get_model_urls('netbox_bgp', 'prefixlistrule'))),
 ]


### PR DESCRIPTION
Fixes #209 

- Removing block `tabs` from HTML as inherited
- Replacing in `urls.py` ObjectChangeLogView by include(get_model_urls() that add automatically the right views depending on Netbox model class mixins inheritance


<h6>
vagrant@vagrant:~/netbox$ docker compose exec netbox bash -c "./manage.py test netbox_bgp"
🧬 loaded config '/etc/netbox/config/configuration.py'
Found 177 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.................................................................................................................................................................................
----------------------------------------------------------------------
Ran 177 tests in 6.903s

OK
</h6>
