### PR TITLE
Add list of "RoutingPolicyRule" objects to GraphQL "RoutingPolicy" object

### DIFF
--- a/netbox_bgp/graphql/types.py
+++ b/netbox_bgp/graphql/types.py
@@ -82,6 +82,9 @@ class BGPPeerGroupType(NetBoxObjectType):
 class RoutingPolicyType(NetBoxObjectType):
     name: str
     description: str
+    rules: List[
+         Annotated["RoutingPolicyRuleType", strawberry.lazy("netbox_bgp.graphql.types")]
+    ]
 
 
 @strawberry_django.type(

--- a/netbox_bgp/graphql/types.py
+++ b/netbox_bgp/graphql/types.py
@@ -140,7 +140,7 @@ class PrefixListRuleType(NetBoxObjectType):
 class CommunityListType(NetBoxObjectType):
     name: str
     description: str
-    rules: List[
+    commlistrules: List[
          Annotated["CommunityListRuleType", strawberry.lazy("netbox_bgp.graphql.types")]
     ]
 

--- a/netbox_bgp/graphql/types.py
+++ b/netbox_bgp/graphql/types.py
@@ -105,10 +105,10 @@ class RoutingPolicyRuleType(NetBoxObjectType):
         Annotated["CommunityListType", strawberry.lazy("netbox_bgp.graphql.types")]
     ]
     match_ip_address: List[
-        Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")]
+        Annotated["PrefixListType", strawberry.lazy("netbox_bgp.graphql.types")]
     ]
     match_ipv6_address: List[
-        Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")]
+        Annotated["PrefixListType", strawberry.lazy("netbox_bgp.graphql.types")]
     ]
 
 
@@ -117,7 +117,7 @@ class PrefixListType(NetBoxObjectType):
     name: str
     description: str
     family: str
-    rules: List[
+    prefrules: List[
          Annotated["PrefixListRuleType", strawberry.lazy("netbox_bgp.graphql.types")]
     ]
 

--- a/netbox_bgp/graphql/types.py
+++ b/netbox_bgp/graphql/types.py
@@ -117,6 +117,9 @@ class PrefixListType(NetBoxObjectType):
     name: str
     description: str
     family: str
+    rules: List[
+         Annotated["PrefixListRuleType", strawberry.lazy("netbox_bgp.graphql.types")]
+    ]
 
 
 @strawberry_django.type(PrefixListRule, fields="__all__", filters=PrefixListRuleFilter)
@@ -137,6 +140,9 @@ class PrefixListRuleType(NetBoxObjectType):
 class CommunityListType(NetBoxObjectType):
     name: str
     description: str
+    rules: List[
+         Annotated["CommunityListRuleType", strawberry.lazy("netbox_bgp.graphql.types")]
+    ]
 
 
 @strawberry_django.type(


### PR DESCRIPTION
This is a straightforward addition of rules to the RoutingPolicy GraphQL results so the policy has all the relevant bits in one place.