### PR TITLE
Fix BGP Session display under Device view

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,12 @@ See [NetBox Documentation](https://docs.netbox.dev/en/stable/plugins/#installing
 ## Configuration
 
 The following options are available:
-* `device_ext_page`: String (default right) Device related BGP sessions table position. The following values are available:  
-left, right, full_width. Set empty value for disable.
+* `device_ext_page`: String (default right) Device related BGP sessions display mode. The following values are available:  
+  - `left`: Display BGP sessions in the left column of the device detail page
+  - `right`: Display BGP sessions in the right column of the device detail page  
+  - `full_width`: Display BGP sessions in full width at the bottom of the device detail page
+  - `tab`: Display BGP sessions in a dedicated tab on the device detail page
+  - Set empty value to disable device BGP sessions display
 * `top_level_menu`: Bool (default False) Enable top level section navigation menu for the plugin. 
 
 ## Screenshots

--- a/netbox_bgp/template_content.py
+++ b/netbox_bgp/template_content.py
@@ -1,36 +1,62 @@
+from dcim.models import Device
+from django.conf import settings
 from netbox.plugins import PluginTemplateExtension
+from netbox.views.generic import ObjectChildrenView
+from utilities.views import ViewTab, register_model_view
 
+from .filtersets import BGPSessionFilterSet
 from .models import BGPSession
 from .tables import BGPSessionTable
 
+# Load configuration
+config = getattr(settings, "PLUGINS_CONFIG", {}).get("netbox_bgp", {})
+
+# Only register the tab view if configuration is set to 'tab'
+if config.get("device_ext_page", "") == "tab":
+
+    @register_model_view(Device, name="bgp_sessions", path="bgp-sessions")
+    class DeviceBGPSessionTabView(ObjectChildrenView):
+        """View to display BGP sessions for this device in a tab."""
+
+        queryset = Device.objects.all()
+        child_model = BGPSession
+        filterset = BGPSessionFilterSet
+        table = BGPSessionTable
+        template_name = "generic/object_children.html"
+        hide_if_empty = False
+        tab = ViewTab(
+            label="BGP Sessions",
+            badge=lambda obj: BGPSession.objects.filter(device=obj).count(),
+            permission="netbox_bgp.view_bgpsession",
+        )
+
+        def get_children(self, request, parent):
+            """Get BGP sessions for this device."""
+            return BGPSession.objects.filter(device=parent)
+
 
 class DeviceBGPSession(PluginTemplateExtension):
-    models = ('dcim.device',)
+    models = ("dcim.device",)
 
     def left_page(self):
-        if self.context['config'].get('device_ext_page') == 'left':
+        if self.context["config"].get("device_ext_page") == "left":
             return self.x_page()
-        return ''
+        return ""
 
     def right_page(self):
-        if self.context['config'].get('device_ext_page') == 'right':
+        if self.context["config"].get("device_ext_page") == "right":
             return self.x_page()
-        return ''
+        return ""
 
     def full_width_page(self):
-        if self.context['config'].get('device_ext_page') == 'full_width':
+        if self.context["config"].get("device_ext_page") == "full_width":
             return self.x_page()
-        return ''
+        return ""
 
     def x_page(self):
-        obj = self.context['object']
-        sess = BGPSession.objects.filter(device=obj)
-        sess_table = BGPSessionTable(sess)
         return self.render(
-            'netbox_bgp/device_extend.html',
-            extra_context={
-                'related_session_table': sess_table
-            }
+            "netbox_bgp/device_extend.html",
         )
+
 
 template_extensions = [DeviceBGPSession]

--- a/netbox_bgp/templates/netbox_bgp/device_extend.html
+++ b/netbox_bgp/templates/netbox_bgp/device_extend.html
@@ -1,4 +1,5 @@
-{% load render_table from django_tables2 %}
+{% load helpers %}
+
 <div class="card">
     <h5 class="card-header">
         Related BGP Sessions

--- a/netbox_bgp/templates/netbox_bgp/device_extend.html
+++ b/netbox_bgp/templates/netbox_bgp/device_extend.html
@@ -4,6 +4,6 @@
         Related BGP Sessions
     </h5>
     <div class="card-body">
-        {% render_table related_session_table 'inc/table.html' %}
+        {% htmx_table 'plugins:netbox_bgp:bgpsession_list' device_id=object.id %}
     </div>
 </div>


### PR DESCRIPTION
### Summary
This merge request improves the BGP session display functionality on device detail pages by addressing several usability and performance issues.

### Changes Made

**🔧 Performance Improvements:**
- Originally the large table would be displayed as a whole, now it can be paged
- Replaced manual table rendering with `htmx_table` for better performance and built-in pagination

**🎨 UI/UX Improvements:**
- Originally columns would overflow the table, now it takes table configuration from the list view
- Consistent table styling and column configuration across all BGP session views

**⚙️ New Configuration Options:**
- Originally there was no option to display BGP sessions under a Device View Tab, now it is configurable
- Added new `tab` display mode to `device_ext_page` configuration option
- Users can now choose between: `left`, `right`, `full_width`, or `tab` display modes

### Technical Details

- **New Tab View**: Implemented `DeviceBGPSessionTabView` using `ObjectChildrenView` with conditional registration
- **Template Optimization**: Simplified template extension by removing manual table creation and extra context dependencies
- **Configuration Enhancement**: Enhanced documentation with detailed explanations of all display modes

### Configuration Example

```python
PLUGINS_CONFIG = {
    'netbox_bgp': {
        'device_ext_page': 'tab',  # New option: displays BGP sessions in a dedicated tab
    }
}
```

### Files Modified
- template_content.py - Added tab view and improved template handling
- device_extend.html - Replaced manual table with htmx_table
- README.md - Updated documentation with detailed display mode explanations

### Backward Compatibility
✅ All existing display modes (`left`, `right`, `full_width`) continue to work as before
✅ Default behavior remains unchanged (defaults to `right`)