### PR TITLE
API: Reorder and add missing fields in serializers

### DIFF
--- a/netbox_bgp/api/serializers.py
+++ b/netbox_bgp/api/serializers.py
@@ -36,9 +36,11 @@ class ASPathListSerializer(NetBoxModelSerializer):
             "name",
             "display",
             "description",
+            "comments",
             "tags",
             "custom_fields",
-            "comments",
+            "created",
+            "last_updated",
         ]
         brief_fields = ("id", "url", "display", "name", "description")    
 
@@ -51,16 +53,16 @@ class ASPathListRuleSerializer(NetBoxModelSerializer):
         fields = [
             "id",
             "description",
-            "tags",
-            "custom_fields",
             "display",
             "aspath_list",
-            "created",
-            "last_updated",
             "index",
             "action",
             "pattern",
             "comments",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
         ]
         brief_fields = ("id", "display", "description")
 
@@ -77,9 +79,11 @@ class RoutingPolicySerializer(NetBoxModelSerializer):
             "name",
             "description",
             "weight",
+            "comments",
             "tags",
             "custom_fields",
-            "comments",
+            "created",
+            "last_updated",
         )
         brief_fields = ("id", "url", "display", "name", "description")
 
@@ -96,9 +100,11 @@ class PrefixListSerializer(NetBoxModelSerializer):
             "display",
             "description",
             "family",
+            "comments",
             "tags",
             "custom_fields",
-            "comments",
+            "created",
+            "last_updated",
         )
         brief_fields = ("id", "url", "display", "name", "description")
 
@@ -134,7 +140,10 @@ class BGPPeerGroupSerializer(NetBoxModelSerializer):
             "import_policies",
             "export_policies",
             "comments",
+            "tags",
             "custom_fields",
+            "created",
+            "last_updated",
         )
         brief_fields = ("id", "url", "display", "name", "description")
 
@@ -175,8 +184,6 @@ class BGPSessionSerializer(NetBoxModelSerializer):
         fields = (
             "id",
             "url",
-            "tags",
-            "custom_fields",
             "display",
             "status",
             "site",
@@ -194,11 +201,13 @@ class BGPSessionSerializer(NetBoxModelSerializer):
             "max_prefixes",
             "prefix_list_in",
             "prefix_list_out",
-            "created",
-            "last_updated",
             "name",
             "description",
             "comments",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
         )
         brief_fields = ("id", "url", "display", "name", "description")
 
@@ -240,18 +249,18 @@ class CommunitySerializer(NetBoxModelSerializer):
         fields = (
             "id",
             "url",
-            "tags",
-            "custom_fields",
             "display",
             "status",
             "tenant",
-            "created",
-            "last_updated",
             "description",
             "value",
             "site",
             "role",
             "comments",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
         )
         brief_fields = ("id", "url", "display", "value", "description")
 
@@ -267,9 +276,11 @@ class CommunityListSerializer(NetBoxModelSerializer):
             "name",
             "display",
             "description",
+            "comments",
             "tags",
             "custom_fields",
-            "comments",
+            "created",
+            "last_updated",
         )
         brief_fields = ("id", "url", "display", "name", "description")
 
@@ -282,16 +293,16 @@ class CommunityListRuleSerializer(NetBoxModelSerializer):
         model = CommunityListRule
         fields = (
             "id",
-            "tags",
-            "custom_fields",
             "display",
             "description",
             "community_list",
-            "created",
-            "last_updated",
             "action",
             "community",
             "comments",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
         )
         brief_fields = ("id", "display", "description")
 
@@ -357,9 +368,11 @@ class RoutingPolicyRuleSerializer(NetBoxModelSerializer):
             "match_ipv6_address",
             "description",
             "continue_entry",
+            "comments",
             "tags",
             "custom_fields",
-            "comments",
+            "created",
+            "last_updated",
         )
         brief_fields = ("id", "display", "description")
 
@@ -374,12 +387,8 @@ class PrefixListRuleSerializer(NetBoxModelSerializer):
         fields = (
             "id",
             "description",
-            "tags",
-            "custom_fields",
             "display",
             "prefix_list",
-            "created",
-            "last_updated",
             "index",
             "action",
             "prefix_custom",
@@ -387,6 +396,10 @@ class PrefixListRuleSerializer(NetBoxModelSerializer):
             "le",
             "prefix",
             "comments",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
         )
         brief_fields = ("id", "display", "description")
 


### PR DESCRIPTION
## Description

Some model serializers were missing the fields `created`, `last_updated`, or `tags`, which could lead to inconsistent metadata exposure via the API.
This PR adds any missing fields and reorders the `fields` lists to match the conventions used in other NetBox model serializers.

## Changes

**api/serializers.py**
In addition to reordering the `fields` lists, the following changes were made:
- **ASPathListSerializer**: Added `created` and `last_updated`.
- **RoutingPolicySerializer**: Added `created` and `last_updated`.
- **PrefixListSerializer**: Added `created` and `last_updated`.
- **BGPPeerGroupSerializer**: Added `created`, `last_updated`, and `tags`.
- **CommunityListSerializer**: Added `created` and `last_updated`.
- **RoutingPolicyRuleSerializer**: Added `created` and `last_updated`.

## Testing

- Created object instances for each affected model, including tags.
- Verified correct data rendering in both detail and list API views for each model.
