### PR TITLE
Replace FilterLookup[str] with StrFilterLookup[str]

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This plugin provide following Models:
 * BGP Sessions
 * BGP Peer Groups
 * Routing Policy
-* Prefix Lists 
+* Prefix Lists
 * AS Path Lists
 
 ## Compatibility
@@ -27,7 +27,7 @@ This plugin provide following Models:
 
 ## Installation
 
-The plugin is available as a Python package in pypi and can be installed with pip  
+The plugin is available as a Python package in pypi and can be installed with pip
 
 ```
 pip install netbox-bgp
@@ -43,13 +43,13 @@ See [NetBox Documentation](https://docs.netbox.dev/en/stable/plugins/#installing
 ## Configuration
 
 The following options are available:
-* `device_ext_page`: String (default right) Device related BGP sessions display mode. The following values are available:  
+* `device_ext_page`: String (default right) Device related BGP sessions display mode. The following values are available:
   - `left`: Display BGP sessions in the left column of the device detail page
-  - `right`: Display BGP sessions in the right column of the device detail page  
+  - `right`: Display BGP sessions in the right column of the device detail page
   - `full_width`: Display BGP sessions in full width at the bottom of the device detail page
   - `tab`: Display BGP sessions in a dedicated tab on the device detail page
   - Set empty value to disable device BGP sessions display
-* `top_level_menu`: Bool (default False) Enable top level section navigation menu for the plugin. 
+* `top_level_menu`: Bool (default False) Enable top level section navigation menu for the plugin.
 
 ## Screenshots
 

--- a/develop/Dockerfile
+++ b/develop/Dockerfile
@@ -23,6 +23,6 @@ WORKDIR /source
 COPY . /source
 
 #RUN pip install -r requirements.txt
-RUN python -m pip install --editable . 
+RUN python -m pip install --editable .
 
 WORKDIR /opt/netbox/netbox/

--- a/netbox_bgp/api/serializers.py
+++ b/netbox_bgp/api/serializers.py
@@ -40,7 +40,7 @@ class ASPathListSerializer(NetBoxModelSerializer):
             "custom_fields",
             "comments",
         ]
-        brief_fields = ("id", "url", "display", "name", "description")    
+        brief_fields = ("id", "url", "display", "name", "description")
 
 
 class ASPathListRuleSerializer(NetBoxModelSerializer):
@@ -338,7 +338,7 @@ class RoutingPolicyRuleSerializer(NetBoxModelSerializer):
         required=False,
         allow_null=True,
         many=True,
-    )  
+    )
 
     class Meta:
         model = RoutingPolicyRule

--- a/netbox_bgp/api/views.py
+++ b/netbox_bgp/api/views.py
@@ -23,7 +23,7 @@ from netbox_bgp.filtersets import (
 class RootView(APIRootView):
     def get_view_name(self):
         return 'BGP'
-    
+
 
 class BGPSessionViewSet(NetBoxModelViewSet):
     queryset = BGPSession.objects.all()

--- a/netbox_bgp/choices.py
+++ b/netbox_bgp/choices.py
@@ -83,7 +83,7 @@ class IPAddressFamilyChoices(ChoiceSet):
 
     FAMILY_4 = 'ipv4'
     FAMILY_6 = 'ipv6'
-    
+
     CHOICES = (
         (FAMILY_4, 'IPv4'),
         (FAMILY_6, 'IPv6'),

--- a/netbox_bgp/filtersets.py
+++ b/netbox_bgp/filtersets.py
@@ -49,7 +49,7 @@ class ASPathListRuleFilterSet(NetBoxModelFilterSet):
                 | Q(aspath_list_id__icontains=value)
         )
         return queryset.filter(qs_filter)
-        
+
 @register_filterset
 class CommunityFilterSet(NetBoxModelFilterSet, TenancyFilterSet):
 
@@ -197,7 +197,7 @@ class BGPSessionFilterSet(NetBoxModelFilterSet, TenancyFilterSet):
         queryset=Site.objects.all(),
         to_field_name='name',
         label='DSite (name)',
-    )    
+    )
     by_remote_address = django_filters.CharFilter(
         method='search_by_remote_ip',
         label='Remote Address',

--- a/netbox_bgp/forms.py
+++ b/netbox_bgp/forms.py
@@ -64,7 +64,7 @@ class ASPathListRuleFilterForm(NetBoxModelFilterSetForm):
     aspath_list = DynamicModelChoiceField(queryset=ASPathList.objects.all(), required=False)
     tag = TagFilterField(model)
 
-    
+
 class ASPathListForm(NetBoxModelForm):
 
     comments = CommentField()
@@ -103,7 +103,7 @@ class ASPathListRuleImportForm(NetBoxModelImportForm):
 
     class Meta:
         model = ASPathListRule
-        fields = ["aspath_list", "index", "action", "pattern", "description", "tags", "comments"]   
+        fields = ["aspath_list", "index", "action", "pattern", "description", "tags", "comments"]
 
 
 class ASPathListRuleForm(NetBoxModelForm):
@@ -543,7 +543,7 @@ class BGPSessionBulkEditForm(NetBoxModelBulkEditForm):
     local_as = DynamicModelChoiceField(queryset=ASN.objects.all(), required=False)
     remote_as = DynamicModelChoiceField(queryset=ASN.objects.all(), required=False)
     remote_as_macro = forms.CharField(
-        label=_("Remote AS Macro"), 
+        label=_("Remote AS Macro"),
         max_length=255,
         required=False,
     )
@@ -720,7 +720,7 @@ class RoutingPolicyRuleForm(NetBoxModelForm):
         queryset=CommunityList.objects.all(),
         required=False,
     )
-    
+
     match_ip_address = DynamicModelMultipleChoiceField(
         queryset=PrefixList.objects.all(),
         required=False,
@@ -740,7 +740,7 @@ class RoutingPolicyRuleForm(NetBoxModelForm):
     match_aspath_list = DynamicModelMultipleChoiceField(
         queryset=ASPathList.objects.all(),
         required=False,
-    )   
+    )
 
     match_custom = forms.JSONField(
         label="Custom Match",
@@ -910,7 +910,7 @@ class PrefixListRuleImportForm(NetBoxModelImportForm):
             "tags",
             "comments",
         )
-        
+
 class PrefixListRuleForm(NetBoxModelForm):
     prefix = DynamicModelChoiceField(
         queryset=Prefix.objects.all(),

--- a/netbox_bgp/graphql/filters.py
+++ b/netbox_bgp/graphql/filters.py
@@ -120,12 +120,12 @@ class NetBoxBGPSessionFilter(TenancyFilterMixin, NetBoxModelFilter):
         Annotated["IPAddressFilter", strawberry.lazy("ipam.graphql.filters")] | None
     ) = strawberry_django.filter_field()
     local_address_id: ID | None = strawberry_django.filter_field()
-    
+
     remote_address: (
         Annotated["IPAddressFilter", strawberry.lazy("ipam.graphql.filters")] | None
     ) = strawberry_django.filter_field()
     remote_address_id: ID | None = strawberry_django.filter_field()
-    
+
     device: (
         Annotated["DeviceFilter", strawberry.lazy("dcim.graphql.filters")] | None
     ) = strawberry_django.filter_field()
@@ -167,7 +167,7 @@ class NetBoxBGPRoutingPolicyFilter(NetBoxModelFilter):
 
 @strawberry_django.filter_type(RoutingPolicyRule, lookups=True)
 class NetBoxBGPRoutingPolicyRuleFilter(NetBoxModelFilter):
-    description: FilterLookup[str] | None = strawberry_django.filter_field()   
+    description: FilterLookup[str] | None = strawberry_django.filter_field()
     routing_policy: (
         Annotated[
             "NetBoxBGPRoutingPolicyFilter", strawberry.lazy("netbox_bgp.graphql.filters")
@@ -187,7 +187,7 @@ class NetBoxBGPRoutingPolicyRuleFilter(NetBoxModelFilter):
         ]
         | None
     ) = strawberry_django.filter_field()
-    aspath_list_id: ID | None = strawberry_django.filter_field()  
+    aspath_list_id: ID | None = strawberry_django.filter_field()
 
 
 @strawberry_django.filter_type(PrefixList, lookups=True)

--- a/netbox_bgp/graphql/filters.py
+++ b/netbox_bgp/graphql/filters.py
@@ -1,7 +1,7 @@
 import strawberry
 import strawberry_django
 from strawberry.scalars import ID
-from strawberry_django import FilterLookup
+from strawberry_django import StrFilterLookup
 
 from typing import Annotated
 from netbox.graphql.filters import NetBoxModelFilter
@@ -61,12 +61,12 @@ __all__ = (
 
 @strawberry_django.filter_type(ASPathList, lookups=True)
 class NetBoxBGPASPathListFilter(NetBoxModelFilter):
-    name: FilterLookup[str] | None = strawberry_django.filter_field()
-    description: FilterLookup[str] | None = strawberry_django.filter_field()
+    name: StrFilterLookup | None = strawberry_django.filter_field()
+    description: StrFilterLookup | None = strawberry_django.filter_field()
 
 @strawberry_django.filter_type(ASPathListRule, lookups=True)
 class NetBoxBGPASPathListRuleFilter(NetBoxModelFilter):
-    value: FilterLookup[str] | None = strawberry_django.filter_field()
+    value: StrFilterLookup | None = strawberry_django.filter_field()
     aspath_list: (
         Annotated[
             "NetBoxBGPASPathListFilter", strawberry.lazy("netbox_bgp.graphql.filters")
@@ -83,8 +83,8 @@ class NetBoxBGPASPathListRuleFilter(NetBoxModelFilter):
 
 @strawberry_django.filter_type(Community, lookups=True)
 class NetBoxBGPCommunityFilter(TenancyFilterMixin, NetBoxModelFilter):
-    value: FilterLookup[str] | None = strawberry_django.filter_field()
-    description: FilterLookup[str] | None = strawberry_django.filter_field()
+    value: StrFilterLookup | None = strawberry_django.filter_field()
+    description: StrFilterLookup | None = strawberry_django.filter_field()
     status: (
         Annotated[
             "NetBoxBGPCommunityStatusEnum", strawberry.lazy("netbox_bgp.graphql.enums")
@@ -95,8 +95,8 @@ class NetBoxBGPCommunityFilter(TenancyFilterMixin, NetBoxModelFilter):
 
 @strawberry_django.filter_type(BGPSession, lookups=True)
 class NetBoxBGPSessionFilter(TenancyFilterMixin, NetBoxModelFilter):
-    name: FilterLookup[str] | None = strawberry_django.filter_field()
-    description: FilterLookup[str] | None = strawberry_django.filter_field()
+    name: StrFilterLookup | None = strawberry_django.filter_field()
+    description: StrFilterLookup | None = strawberry_django.filter_field()
     status: (
         Annotated[
             "NetBoxBGPSessionStatusEnum", strawberry.lazy("netbox_bgp.graphql.enums")
@@ -109,7 +109,7 @@ class NetBoxBGPSessionFilter(TenancyFilterMixin, NetBoxModelFilter):
     ) = strawberry_django.filter_field()
     remote_as_id: ID | None = strawberry_django.filter_field()
 
-    remote_as_macro: FilterLookup[str] | None = strawberry_django.filter_field()
+    remote_as_macro: StrFilterLookup | None = strawberry_django.filter_field()
 
     local_as: (
         Annotated["ASNFilter", strawberry.lazy("ipam.graphql.filters")] | None
@@ -152,22 +152,22 @@ class NetBoxBGPSessionFilter(TenancyFilterMixin, NetBoxModelFilter):
         | None
     ) = strawberry_django.filter_field()
 
-    max_prefixes: FilterLookup[int] | None = strawberry_django.filter_field()
+    max_prefixes: StrFilterLookup | None = strawberry_django.filter_field()
 
 
 @strawberry_django.filter_type(BGPPeerGroup, lookups=True)
 class NetBoxBGPBGPPeerGroupFilter(NetBoxModelFilter):
-    name: FilterLookup[str] | None = strawberry_django.filter_field()
-    description: FilterLookup[str] | None = strawberry_django.filter_field()
+    name: StrFilterLookup | None = strawberry_django.filter_field()
+    description: StrFilterLookup | None = strawberry_django.filter_field()
 
 @strawberry_django.filter_type(RoutingPolicy, lookups=True)
 class NetBoxBGPRoutingPolicyFilter(NetBoxModelFilter):
-    name: FilterLookup[str] | None = strawberry_django.filter_field()
-    description: FilterLookup[str] | None = strawberry_django.filter_field()
+    name: StrFilterLookup | None = strawberry_django.filter_field()
+    description: StrFilterLookup | None = strawberry_django.filter_field()
 
 @strawberry_django.filter_type(RoutingPolicyRule, lookups=True)
 class NetBoxBGPRoutingPolicyRuleFilter(NetBoxModelFilter):
-    description: FilterLookup[str] | None = strawberry_django.filter_field()
+    description: StrFilterLookup | None = strawberry_django.filter_field()
     routing_policy: (
         Annotated[
             "NetBoxBGPRoutingPolicyFilter", strawberry.lazy("netbox_bgp.graphql.filters")
@@ -192,8 +192,8 @@ class NetBoxBGPRoutingPolicyRuleFilter(NetBoxModelFilter):
 
 @strawberry_django.filter_type(PrefixList, lookups=True)
 class NetBoxBGPPrefixListFilter(NetBoxModelFilter):
-    name: FilterLookup[str] | None = strawberry_django.filter_field()
-    description: FilterLookup[str] | None = strawberry_django.filter_field()
+    name: StrFilterLookup | None = strawberry_django.filter_field()
+    description: StrFilterLookup | None = strawberry_django.filter_field()
     family: (
         Annotated[
             "NetBoxBGPIPAddressFamilyEnum", strawberry.lazy("netbox_bgp.graphql.enums")
@@ -222,8 +222,8 @@ class NetBoxBGPPrefixListRuleFilter(NetBoxModelFilter):
 
 @strawberry_django.filter_type(CommunityList, lookups=True)
 class NetBoxBGPCommunityListFilter(NetBoxModelFilter):
-    name: FilterLookup[str] | None = strawberry_django.filter_field()
-    description: FilterLookup[str] | None = strawberry_django.filter_field()
+    name: StrFilterLookup | None = strawberry_django.filter_field()
+    description: StrFilterLookup | None = strawberry_django.filter_field()
 
 
 @strawberry_django.filter_type(CommunityListRule, lookups=True)
@@ -242,6 +242,5 @@ class NetBoxBGPCommunityListRuleFilter(NetBoxModelFilter):
         | None
     ) = strawberry_django.filter_field()
     community_list_id: ID | None = strawberry_django.filter_field()
-
 
 

--- a/netbox_bgp/models.py
+++ b/netbox_bgp/models.py
@@ -396,7 +396,7 @@ class BGPSession(NetBoxModel):
         to='virtualization.VirtualMachine',
         on_delete=models.PROTECT,
         null=True,
-        blank=True,        
+        blank=True,
     )
     max_prefixes = models.PositiveIntegerField(
         null=True,
@@ -508,7 +508,7 @@ class BGPSession(NetBoxModel):
         """
         if self.name:
             return self.name
-        return f'{self.remote_address}:{self.remote_as}'  
+        return f'{self.remote_address}:{self.remote_as}'
 
 
 class RoutingPolicyRule(NetBoxModel):
@@ -565,7 +565,7 @@ class RoutingPolicyRule(NetBoxModel):
     )
     comments = models.TextField(
         blank=True
-    )    
+    )
 
     class Meta:
         ordering = ['routing_policy', 'index']

--- a/netbox_bgp/navigation.py
+++ b/netbox_bgp/navigation.py
@@ -41,7 +41,7 @@ _menu_items_primary = (
                 permissions=['netbox_bgp.add_communitylist'],
             ),
         ),
-    ),    
+    ),
     PluginMenuItem(
         link='plugins:netbox_bgp:bgpsession_list',
         link_text='Sessions',
@@ -155,7 +155,7 @@ _menu_items_primary = (
                 permissions=['netbox_bgp.add_aspathlist'],
             ),
         ),
-    ),    
+    ),
     PluginMenuItem(
         link='plugins:netbox_bgp:aspathlistrule_list',
         link_text='AS Path List Rules',
@@ -174,7 +174,7 @@ _menu_items_primary = (
                 permissions=['netbox_bgp.add_aspathlistrule'],
             ),
         ),
-    ),    
+    ),
     PluginMenuItem(
         link='plugins:netbox_bgp:bgppeergroup_list',
         link_text='Peer Groups',
@@ -235,7 +235,7 @@ _menu_items_grouped = (
                 permissions=['netbox_bgp.add_communitylist'],
             ),
         ),
-    ),    
+    ),
     PluginMenuItem(
         link='plugins:netbox_bgp:bgpsession_list',
         link_text='Sessions',
@@ -296,7 +296,7 @@ _aspath_list_menu = (
                 permissions=['netbox_bgp.add_aspathlist'],
             ),
         ),
-    ),  
+    ),
     PluginMenuItem(
         link='plugins:netbox_bgp:aspathlistrule_list',
         link_text='AS Path List Rules',
@@ -315,8 +315,8 @@ _aspath_list_menu = (
                 permissions=['netbox_bgp.add_aspathlistrule'],
             ),
         ),
-    ),   
-)   
+    ),
+)
 
 _routing_policy_menu = (
     PluginMenuItem(
@@ -404,7 +404,7 @@ _prefix_list_menu = (
 plugin_settings = settings.PLUGINS_CONFIG.get('netbox_bgp', {})
 
 if plugin_settings.get('top_level_menu'):
-    menu = PluginMenu(  
+    menu = PluginMenu(
         label="BGP",
         groups=(
             ("BGP", _menu_items_grouped),

--- a/netbox_bgp/templates/netbox_bgp/aspathlist.html
+++ b/netbox_bgp/templates/netbox_bgp/aspathlist.html
@@ -51,7 +51,7 @@
             <div class="card-body">
                 {% render_table rprules_table 'inc/table.html' %}
             </div>
-        </div>     
+        </div>
         {% plugin_right_page object %}
     </div>
 </div>

--- a/netbox_bgp/templates/netbox_bgp/aspathlistrule.html
+++ b/netbox_bgp/templates/netbox_bgp/aspathlistrule.html
@@ -30,7 +30,7 @@
                     <tr>
                         <th scope="row">Description</th>
                         <td>{{ object.description|placeholder }}</td>
-                    </tr>                    
+                    </tr>
                 </table>
             </div>
         </div>

--- a/netbox_bgp/templates/netbox_bgp/bgpsession.html
+++ b/netbox_bgp/templates/netbox_bgp/bgpsession.html
@@ -144,7 +144,7 @@
                             <span class="text-muted">None</span>
                             {% endif %}
                         </td>
-                    </tr>                                        
+                    </tr>
                     <tr>
                         <td>Description</td>
                         <td>{{ object.description|placeholder }}</td>

--- a/netbox_bgp/templates/netbox_bgp/prefixlist.html
+++ b/netbox_bgp/templates/netbox_bgp/prefixlist.html
@@ -63,7 +63,7 @@
             <div class="card-body">
                 {% render_table sess_table 'inc/table.html' %}
             </div>
-        </div>        
+        </div>
         {% plugin_right_page object %}
     </div>
 </div>

--- a/netbox_bgp/tests/test_views.py
+++ b/netbox_bgp/tests/test_views.py
@@ -21,7 +21,7 @@ class ASPathListRuleTestCase(ViewTestCases.BulkImportObjectsViewTestCase):
             self.model._meta.app_label,
             self.model._meta.model_name
         )
- 
+
     @classmethod
     def setUpTestData(cls):
         aspathlists = [
@@ -51,7 +51,7 @@ class PrefixListRuleTestCase(ViewTestCases.BulkImportObjectsViewTestCase):
             self.model._meta.app_label,
             self.model._meta.model_name
         )
- 
+
     @classmethod
     def setUpTestData(cls):
         prefixes = [
@@ -86,7 +86,7 @@ class RoutingPolicyRuleTestCase(ViewTestCases.BulkImportObjectsViewTestCase):
             self.model._meta.app_label,
             self.model._meta.model_name
         )
- 
+
     @classmethod
     def setUpTestData(cls):
         aspathlists = [

--- a/netbox_bgp/views.py
+++ b/netbox_bgp/views.py
@@ -549,7 +549,7 @@ class ASPathListBulkImportView(generic.BulkImportView):
     queryset = ASPathList.objects.all()
     model_form = forms.ASPathListImportForm
 
-# AS Path List Rule 
+# AS Path List Rule
 
 @register_model_view(ASPathListRule, "list", path="", detail=False)
 class ASPathListRuleListView(generic.ObjectListView):


### PR DESCRIPTION
NetBox 4.5.4 has done these changes as well, due using strawberry_django v0.79, where FilterLookup is deprecated.

Corresponding issue: https://github.com/netbox-community/netbox/issues/21450

(I also made a code clean up commit because there were quite a few instances of trailing whitespaces)