### PR TITLE
Make ge/le nullable in PrefixListRule GraphQL type

### DIFF
--- a/netbox_bgp/graphql/types.py
+++ b/netbox_bgp/graphql/types.py
@@ -160,8 +160,8 @@ class PrefixListRuleType(NetBoxObjectType):
     action: str
     prefix: Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")] | None
     prefix_custom: str | None
-    ge: BigInt
-    le: BigInt
+    ge: BigInt | None
+    le: BigInt | None
     description: str
 
 


### PR DESCRIPTION
The ge/le model fields are PositiveSmallIntegerField(null=True), but the strawberry type declared them non-nullable — a rule without ge/le raised a null violation that failed the whole GraphQL query.